### PR TITLE
[fix] Remove double slashes from generated paths

### DIFF
--- a/packaged/Makefile.am
+++ b/packaged/Makefile.am
@@ -85,5 +85,5 @@ endif
 
 .l.c:
 	$(LEX) $(AM_LFLAGS) $(LFLAGS) -o $@ $<
-
+	sed 's#//bxiutil#/bxiutil#g' -i $@
 #########################################################


### PR DESCRIPTION
Cause compilation failures in some environments